### PR TITLE
Fixes crash (EXC_BAD_ACCESS in objc_moveWeak → _CFXNotificationRegistrarAddObserver) at ViewTracker.init

### DIFF
--- a/NowYouSeeMe.podspec
+++ b/NowYouSeeMe.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'NowYouSeeMe'
-  s.version          = '1.0.3'
+  s.version          = '1.0.4'
   s.summary          = 'View tracking framework for iOS'
 
   s.description      = <<-DESC

--- a/Source/Classes/Debug/Tracker/DebugViewTracker.swift
+++ b/Source/Classes/Debug/Tracker/DebugViewTracker.swift
@@ -32,6 +32,10 @@ public class DebugViewTracker: ViewTracker {
         NotificationCenter.default.addObserver(self, selector: #selector(hideOverlay), name: DebugNotifications.hideOverlay, object: nil)
     }
 
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
     /**
      Displays overlay view
      */

--- a/Source/Classes/NowYouSeeMe.swift
+++ b/Source/Classes/NowYouSeeMe.swift
@@ -65,4 +65,17 @@ import Foundation
      - **false** -> framework is **disabled**
     */
     internal private(set) static var watching: Bool = false
+
+    /**
+     When enabled, view trackers use a single shared app lifecycle observer instead of
+     registering per-instance `NSNotificationCenter` observers.
+     */
+    internal private(set) static var useSharedAppLifecycleNotifier: Bool = false
+
+    /**
+     Configures view tracker lifecycle handling. Call before `seeMe()` / `seeReact()`.
+     */
+    @objc public static func configure(viewTrackerLifecycleFixEnabled: Bool) {
+        useSharedAppLifecycleNotifier = viewTrackerLifecycleFixEnabled
+    }
 }

--- a/Source/Classes/Tracker/AppLifecycleNotifier.swift
+++ b/Source/Classes/Tracker/AppLifecycleNotifier.swift
@@ -1,0 +1,66 @@
+//
+//  AppLifecycleNotifier.swift
+//  NowYouSeeMe
+//
+//  Copyright © 2020 Flipkart. All rights reserved.
+//
+
+import UIKit
+
+/// Registers one pair of app lifecycle observers and fans out to active view trackers.
+internal final class AppLifecycleNotifier: NSObject {
+    static let shared = AppLifecycleNotifier()
+
+    private var trackers: Set<WeakRef<ViewTracker>> = []
+
+    private override init() {
+        super.init()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(appWillResignActive),
+            name: UIApplication.willResignActiveNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(appDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+    }
+
+    func register(_ tracker: ViewTracker) {
+        QueueManager.dispatchOnSerialQueue { [weak self] in
+            self?.trackers.insert(WeakRef(tracker))
+            self?.prune()
+        }
+    }
+
+    func unregister(_ tracker: ViewTracker) {
+        if QueueManager.isSerialQueue {
+            trackers = trackers.filter { $0.value != tracker && $0.value != nil }
+        } else {
+            QueueManager.serialQueue.sync {
+                trackers = trackers.filter { $0.value != tracker && $0.value != nil }
+            }
+        }
+    }
+
+    private func prune() {
+        trackers = trackers.filter { $0.value != nil }
+    }
+
+    @objc private func appWillResignActive() {
+        QueueManager.dispatchOnSerialQueue { [weak self] in
+            self?.prune()
+            self?.trackers.forEach { $0.value?.appWillResignActive() }
+        }
+    }
+
+    @objc private func appDidBecomeActive() {
+        QueueManager.dispatchOnSerialQueue { [weak self] in
+            self?.prune()
+            self?.trackers.forEach { $0.value?.appDidBecomeActive() }
+        }
+    }
+}

--- a/Source/Classes/Tracker/ViewTracker.swift
+++ b/Source/Classes/Tracker/ViewTracker.swift
@@ -112,6 +112,8 @@ public class ViewTracker: NSObject {
     deinit {
         if NowYou.useSharedAppLifecycleNotifier {
             AppLifecycleNotifier.shared.unregister(self)
+        } else {
+            NotificationCenter.default.removeObserver(self)
         }
 
         // remove self from tracking heirarchy

--- a/Source/Classes/Tracker/ViewTracker.swift
+++ b/Source/Classes/Tracker/ViewTracker.swift
@@ -91,8 +91,12 @@ public class ViewTracker: NSObject {
         super.init()
 
         // add observers for app state
-        NotificationCenter.default.addObserver(self, selector: #selector(appWillResignActive), name: UIApplication.willResignActiveNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(appDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
+        if NowYou.useSharedAppLifecycleNotifier {
+            AppLifecycleNotifier.shared.register(self)
+        } else {
+            NotificationCenter.default.addObserver(self, selector: #selector(appWillResignActive), name: UIApplication.willResignActiveNotification, object: nil)
+            NotificationCenter.default.addObserver(self, selector: #selector(appDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
+        }
 
         // add self in tracking heirarchy
         addNode()
@@ -106,6 +110,10 @@ public class ViewTracker: NSObject {
     }
 
     deinit {
+        if NowYou.useSharedAppLifecycleNotifier {
+            AppLifecycleNotifier.shared.unregister(self)
+        }
+
         // remove self from tracking heirarchy
         removeNode()
         // remove observers


### PR DESCRIPTION
Each ViewTracker registered two NSNotificationCenter observers for app lifecycle. With NowYouSeeReact swizzling every RCTView.init → trackView(), RN batch view creation caused massive per-view NC registration churn and crashed in the notification registrar.

This change replaces per-view lifecycle observers with a single AppLifecycleNotifier when enabled via NowYou.configure(viewTrackerLifecycleFixEnabled:)